### PR TITLE
Add bracktrace output

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ This will print, when executed:
 Error: this is some context
 caused by: root cause failure
 ```
+
+If the environment variable RUST_BACKTRACE=1 is set, then the printing will
+include whatever backtrace information is provided by the `failure::Error`
+that is being wrapped.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@
 //!
 //! Basically, ExitFailure should only ever be used in the return type for
 //! `main() -> Result<(), exitfailure::ExitFailure>`
+//!
+//! Will also include the backtrace as prepared by the failure::Error crate,
+//! if the environment variable RUST_BACKTRACE=1 is set.
 extern crate failure;
 
 /// The newtype wrapper around `failure::Error`
@@ -27,6 +30,8 @@ extern crate failure;
 /// ```
 pub struct ExitFailure(failure::Error);
 
+/// Prints a list of causes for this Error, along with any backtrace
+/// information collected by the Error (if RUST_BACKTRACE=1).
 impl std::fmt::Debug for ExitFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         use failure::Fail;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,11 @@ impl std::fmt::Debug for ExitFailure {
         let mut fail: &Fail = self.0.cause();
         write!(f, "{}", fail)?;
         while let Some(cause) = fail.cause() {
-            write!(f, "\ncaused by: {}", cause)?;
+            write!(f, "\nInfo: caused by {}", cause)?;
             fail = cause;
         }
+
+        write!(f, "{}", self.0.backtrace())?;
         Ok(())
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -13,7 +13,7 @@ fn test_example() {
     assert_cli::Assert::command(&[bin])
         .fails()
         .stderr()
-        .contains("Error: this is some context\ncaused by: root cause failure")
+        .contains("Error: this is some context\nInfo: caused by root cause failure")
         .unwrap();
 }
 
@@ -23,6 +23,6 @@ fn test_context() {
     assert_cli::Assert::command(&[bin])
         .fails()
         .stderr()
-        .contains("Error: this is some context\ncaused by: root cause failure")
+        .contains("Error: this is some context\nInfo: caused by root cause failure")
         .unwrap();
 }


### PR DESCRIPTION
When RUST_BACKTRACE=1 is set, the failure::Error object will have a backtrace information I can include in the output. Lets do so.