### PR TITLE
fix: Make backtrace work with nonzero values of RUST_BACKTRACE

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ impl std::fmt::Debug for ExitFailure {
         }
 
         if let Ok(x) = std::env::var("RUST_BACKTRACE") {
-            if x == "1" {
+            if x != "0" {
                 write!(f, "\n{}", self.0.backtrace())?
             }
         }


### PR DESCRIPTION
E.g. RUST_BACKTRACE=full or RUST_BACKTRACE=short as well as
RUST_BACKTRACE=1