### PR TITLE
Fix builds on newer Rust versions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@
 //! Basically, these types should only ever be used in the return type for
 //! `main()`
 //!
+// Required for Rust 1.26 compatibility; unnecessary on newer compilers.
+#[allow(unused_extern_crates)]
 extern crate failure;
 
 /// The newtype wrapper around `failure::Error`

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -54,7 +54,7 @@ fn test_display() {
 #[test]
 fn test_no_backtrace() {
     let bin = format!("{}/target/debug/examples/example", get_cwd());
-    let pred = predicates::str::contains("stack backtrace").from_utf8();
+    let pred = predicates::str::contains("example::some_fn").from_utf8();
     std::process::Command::new(&bin)
         .env_remove("RUST_BACKTRACE")
         .assert()
@@ -65,7 +65,7 @@ fn test_no_backtrace() {
 #[test]
 fn test_backtrace() {
     let bin = format!("{}/target/debug/examples/example", get_cwd());
-    let pred = predicates::str::contains("stack backtrace").from_utf8();
+    let pred = predicates::str::contains("example::some_fn").from_utf8();
     std::process::Command::new(&bin)
         .env("RUST_BACKTRACE", "1")
         .assert()


### PR DESCRIPTION
## What changed

- Allow the intentional `extern crate failure` declaration required by Rust 1.26 while retaining the crate-wide unused-extern lint.
- Make backtrace tests assert on a stable stack frame instead of the formatter-specific `stack backtrace` heading.

## Why

Newer Rust compilers classify the Rust 1.26-compatible `extern crate` declaration as unused, causing builds to fail because the crate denies that lint. Current backtrace formatting also omits the heading expected by the test suite.

This restores builds on current Rust without changing the public API or dropping the documented Rust 1.26 source compatibility.

## Validation

- `cargo build`
- `cargo test` (9 tests passed)
- `git diff --check`
