### PR TITLE
build(deps): configure Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## What changed

- Enable GitHub-native Dependabot version updates for the root Cargo manifest.
- Check for updates weekly.
- Limit version-update pull requests to five at a time.

## Why

PR #39 contains the original 2021 Dependabot Preview migration, but it is stale and has no CI results. This replaces it with a focused configuration based on the current default branch and a lower-noise schedule.

## Impact

GitHub will check Cargo dependencies weekly and open up to five version-update pull requests. Runtime behavior is unchanged.

## Validation

- `git diff --check origin/master...HEAD`
- Configuration reviewed against GitHub's current Dependabot version 2 schema.

Supersedes #39.
